### PR TITLE
Added registrationOptions argument

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -158,13 +158,14 @@ export const useServiceWorker = () => {
   return React.useContext(serviceWorkerContext);
 };
 
-const useProvideServiceWorker = (file = 'sw.js') => {
+const useProvideServiceWorker = (file = 'sw.js', registrationOptions = {} ) => {
   const [swState, dispatch] = React.useReducer(
     useServiceWorkerReducer,
     initialState
   );
   React.useEffect(() => {
     register(file, {
+      registrationOptions: registrationOptions,
       ready: registration => {
         dispatch({
           type: 'SERVICE_WORKER_READY',


### PR DESCRIPTION
register-service-worker supports registrationOptions that might be useful for configurations

```
register('/service-worker.js', {
  registrationOptions: { scope: './' },  <--- here
  ready (registration) {
```